### PR TITLE
LLDB Debug Info

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -87,9 +87,11 @@ public:
   /* Destructor */
   ~string() { delete[] string_value; }
 
-  char &operator[](const unsigned int index) { return at(index); }
+  char &operator[](const unsigned int index) { return this->at(index); }
 
-  const char operator[](const unsigned int index) const { return at(index); }
+  const char operator[](const unsigned int index) const {
+    return this->at(index);
+  }
 
   string operator+(const char rhs) const {
     string output(*this);
@@ -299,7 +301,7 @@ public:
     char lhsChar;
     char rhsChar;
     for (unsigned int charIdx = 0u; charIdx < str_len; ++charIdx) {
-      lhsChar = at(charIdx);
+      lhsChar = this->at(charIdx);
       rhsChar = rhs.at(charIdx);
       if (lhsChar != rhsChar)
         return false;
@@ -314,7 +316,7 @@ public:
     char lhsChar;
     char rhsChar;
     for (unsigned int charIdx = 0u; charIdx < str_len; ++charIdx) {
-      lhsChar = at(charIdx);
+      lhsChar = this->at(charIdx);
       rhsChar = rhs[charIdx];
       if (lhsChar != rhsChar)
         return false;
@@ -355,7 +357,7 @@ public:
     const unsigned int len = length();
     char currChar;
     for (unsigned int idx = 0u; idx < len; ++idx) {
-      currChar = at(idx);
+      currChar = this->at(idx);
       if (currChar == searchChar) {
         return static_cast<int>(idx);
       }

--- a/tools/lldbatl.py
+++ b/tools/lldbatl.py
@@ -1,11 +1,7 @@
-import lldb
-import lldb.formatters.Logger
 
-
-def atlsharedprtr_SummaryProvider(valobj, dict):
+def atlsharedprtr_SummaryProvider(valobj, dict_env):
     ptr = valobj.GetChildMemberWithName('ptr')
-    refCount = valobj.GetChildMemberWithName('refCount')
-    
+        
     type_name = ptr.GetTypeName()
     if type_name == None:
         return "nullptr"
@@ -13,7 +9,7 @@ def atlsharedprtr_SummaryProvider(valobj, dict):
 
 class atlshared_ptr_SynthProvider:
 
-    def __init__(self, valobj, dict):
+    def __init__(self, valobj, dict_env):
         self.valobj = valobj
         self.update()
 
@@ -44,7 +40,7 @@ class atlshared_ptr_SynthProvider:
         return True
 
 
-def atlstring_SummaryProvider(valobj, dict):
+def atlstring_SummaryProvider(valobj, dict_env):
     string_value = valobj.GetChildMemberWithName('string_value').GetSummary()
     if len(string_value) > 25:
         string_value = "\"[...]" + string_value[-25:]
@@ -52,7 +48,7 @@ def atlstring_SummaryProvider(valobj, dict):
 
 class atlvector_SynthProvider:
 
-    def __init__(self, valobj, dict):
+    def __init__(self, valobj, dict_env):
         self.valobj = valobj
         self.update()
 
@@ -87,10 +83,10 @@ class atlvector_SynthProvider:
         return True
 
 
-def atlvector_SummaryProvider(valobj, dict):
+def atlvector_SummaryProvider(valobj, dict_env):
     return "size={}".format(valobj.GetNumChildren())
 
-def __lldb_init_module(debugger, dict):
+def __lldb_init_module(debugger, dict_env):
     debugger.HandleCommand('type summary add -F'
                            'lldbatl.atlsharedprtr_SummaryProvider -e -x "^atl::shared_ptr<.+>$"')
     debugger.HandleCommand('type synthetic add -l'

--- a/tools/lldbatl.py
+++ b/tools/lldbatl.py
@@ -1,11 +1,12 @@
 
 def atlsharedprtr_SummaryProvider(valobj, dict_env):
     ptr = valobj.GetChildMemberWithName('ptr')
-        
+
     type_name = ptr.GetTypeName()
     if type_name == None:
         return "nullptr"
     return "<{}>".format(type_name).replace(" *", "")
+
 
 class atlshared_ptr_SynthProvider:
 
@@ -15,7 +16,7 @@ class atlshared_ptr_SynthProvider:
 
     def num_children(self):
         return 1
-        
+
     def get_child_index(self, name):
         return 0
 
@@ -46,6 +47,7 @@ def atlstring_SummaryProvider(valobj, dict_env):
         string_value = "\"[...]" + string_value[-25:]
     return string_value
 
+
 class atlvector_SynthProvider:
 
     def __init__(self, valobj, dict_env):
@@ -75,7 +77,8 @@ class atlvector_SynthProvider:
 
     def update(self):
         self.elements = self.valobj.GetChildMemberWithName('elements')
-        self.elements_used = self.valobj.GetChildMemberWithName('elements_used')
+        self.elements_used = self.valobj.GetChildMemberWithName(
+            'elements_used')
         self.data_type = self.elements.GetType().GetPointeeType()
         self.data_size = self.data_type.GetByteSize()
 
@@ -85,6 +88,7 @@ class atlvector_SynthProvider:
 
 def atlvector_SummaryProvider(valobj, dict_env):
     return "size={}".format(valobj.GetNumChildren())
+
 
 def __lldb_init_module(debugger, dict_env):
     debugger.HandleCommand('type summary add -F'

--- a/tools/lldbatl.py
+++ b/tools/lldbatl.py
@@ -1,0 +1,51 @@
+import lldb
+import lldb.formatters.Logger
+
+class atlvector_SynthProvider:
+
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+        self.update()
+
+    def num_children(self):
+        num_elems = self.elements_used.GetValueAsUnsigned()
+        return num_elems
+
+    def get_child_index(self, name):
+        return int(name.lstrip('[').rstrip(']'))
+
+    def get_child_at_index(self, index):
+        if index < 0 or index >= self.num_children():
+            return None
+        offset = index * self.data_size
+        return self.elements.CreateChildAtOffset('[' + str(index) + ']', offset, self.data_type)
+
+    def get_type_from_name(self):
+        import re
+        name = self.valobj.GetType().GetName()
+        res = re.match("^(atl::)?vector<(.+)>$", name)
+        if res:
+            return res.group(2)
+        res = re.match("^(atl::)?vector<(.+), \d+>$", name)
+        if res:
+            return res.group(2)
+        return None
+
+    def update(self):
+        self.elements = self.valobj.GetChildMemberWithName('elements')
+        self.elements_used = self.valobj.GetChildMemberWithName('elements_used')
+        self.data_type = self.elements.GetType().GetPointeeType()
+        self.data_size = self.data_type.GetByteSize()
+
+    def has_children(self):
+        return True
+
+
+def atlvector_SummaryProvider(valobj, dict):
+    return "size={}".format(valobj.GetNumChildren())
+
+def __lldb_init_module(debugger, dict):
+    debugger.HandleCommand('type summary add -F'
+                           'libatl.atlvector_SummaryProvider -e -x "^atl::vector<.+>$"')
+    debugger.HandleCommand('type synthetic add -l'
+                           'libatl.atlvector_SynthProvider -x "^atl::vector<.+>$"')

--- a/tools/lldbatl.py
+++ b/tools/lldbatl.py
@@ -46,6 +46,6 @@ def atlvector_SummaryProvider(valobj, dict):
 
 def __lldb_init_module(debugger, dict):
     debugger.HandleCommand('type summary add -F'
-                           'libatl.atlvector_SummaryProvider -e -x "^atl::vector<.+>$"')
+                           'lldbatl.atlvector_SummaryProvider -e -x "^atl::vector<.+>$"')
     debugger.HandleCommand('type synthetic add -l'
-                           'libatl.atlvector_SynthProvider -x "^atl::vector<.+>$"')
+                           'lldbatl.atlvector_SynthProvider -x "^atl::vector<.+>$"')

--- a/tools/lldbatl.py
+++ b/tools/lldbatl.py
@@ -1,6 +1,43 @@
 import lldb
 import lldb.formatters.Logger
 
+
+def atlsharedprtr_SummaryProvider(valobj, dict):
+    return valobj.GetChildMemberWithName('refCount').Dereference().GetValueAsUnsigned()
+
+class atlshared_ptr_SynthProvider:
+
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+        self.update()
+
+    def num_children(self):
+        return 1
+        
+    def get_child_index(self, name):
+        return 0
+
+    def get_child_at_index(self, index):
+        return self.ptr.Dereference()
+
+    def get_type_from_name(self):
+        import re
+        name = self.valobj.GetType().GetName()
+        res = re.match("^(atl::)?shared_ptr<(.+)>$", name)
+        if res:
+            return res.group(2)
+        res = re.match("^(atl::)?shared_ptr<(.+), \d+>$", name)
+        if res:
+            return res.group(2)
+        return None
+
+    def update(self):
+        self.ptr = self.valobj.GetChildMemberWithName('ptr')
+
+    def has_children(self):
+        return True
+
+
 def atlstring_SummaryProvider(valobj, dict):
     return valobj.GetChildMemberWithName('string_value').GetSummary()
 
@@ -48,6 +85,10 @@ def atlvector_SummaryProvider(valobj, dict):
     return "size={}".format(valobj.GetNumChildren())
 
 def __lldb_init_module(debugger, dict):
+    debugger.HandleCommand('type summary add -F'
+                           'lldbatl.atlsharedprtr_SummaryProvider -e -x "^atl::shared_ptr<.+>$"')
+    debugger.HandleCommand('type synthetic add -l'
+                           'lldbatl.atlshared_ptr_SynthProvider -x "^atl::shared_ptr<.+>$"')
     debugger.HandleCommand('type summary add -F'
                            'lldbatl.atlstring_SummaryProvider atl::string')
     debugger.HandleCommand('type summary add -F'

--- a/tools/lldbatl.py
+++ b/tools/lldbatl.py
@@ -1,6 +1,9 @@
 import lldb
 import lldb.formatters.Logger
 
+def atlstring_SummaryProvider(valobj, dict):
+    return valobj.GetChildMemberWithName('string_value').GetSummary()
+
 class atlvector_SynthProvider:
 
     def __init__(self, valobj, dict):
@@ -45,6 +48,8 @@ def atlvector_SummaryProvider(valobj, dict):
     return "size={}".format(valobj.GetNumChildren())
 
 def __lldb_init_module(debugger, dict):
+    debugger.HandleCommand('type summary add -F'
+                           'lldbatl.atlstring_SummaryProvider atl::string')
     debugger.HandleCommand('type summary add -F'
                            'lldbatl.atlvector_SummaryProvider -e -x "^atl::vector<.+>$"')
     debugger.HandleCommand('type synthetic add -l'


### PR DESCRIPTION
Provide cleaner summaries and synthetic children for `atl::vector`, `atl::string`, and `atl::shared_ptr`.